### PR TITLE
Fix download link for new dataset split

### DIFF
--- a/utils/download_data.sh
+++ b/utils/download_data.sh
@@ -9,7 +9,7 @@
 wget --show-progress -O data/attr-ops-data.tar.gz https://www.cs.utexas.edu/~tushar/attribute-ops/attr-ops-data.tar.gz
 wget --show-progress -O data/mitstates.zip http://wednesday.csail.mit.edu/joseph_result/state_and_transformation/release_dataset.zip
 wget --show-progress -O data/utzap.zip http://vision.cs.utexas.edu/projects/finegrained/utzap50k/ut-zap50k-images.zip
-wget --show-progress -O data/splits.tar.gz http://www.cs.cmu.edu/~spurushw/projects/compositional/compositional_split_natural.tar.gz
+wget --show-progress -O data/splits.tar.gz http://www.cs.cmu.edu/~spurushw/publication/compositional/compositional_split_natural.tar.gz
 
 echo "Data downloaded. Extracting files..."
 


### PR DESCRIPTION
The download path has been changed on the original author's website.